### PR TITLE
Extension for comprehensive iTerm2 layouts

### DIFF
--- a/bin/termup
+++ b/bin/termup
@@ -3,5 +3,9 @@
 # Abort beautifully with ctrl+c.
 Signal.trap(:INT) { abort "\nAborting." }
 
+# For debugging local script and not conflicting with the installed gem
+# require File.expand_path(File.join(File.dirname(__FILE__), "../lib/termup/cli.rb"))
+# require File.expand_path(File.join(File.dirname(__FILE__), "../lib/termup/base.rb"))
+
 require 'termup'
 Termup::Cli.start

--- a/lib/templates/iterm2.yml
+++ b/lib/templates/iterm2.yml
@@ -1,0 +1,40 @@
+# COMMENT OF SCRIPT HERE
+#
+# Available layout commands are:
+#    new_tab 
+#    close_tab
+#    go_to_previous_tab
+#    go_to_next_tab
+#    split_horizontally
+#    split_vertically
+#    go_left
+#    go_right
+#    go_down
+#    go_up
+#
+---
+tabs:
+  - tab1:
+      commands:
+        - echo tab1
+      layout: 
+        - split_vertically
+  - tab2:
+      commands:
+        - echo tab2
+      layout: 
+        - split_horizontally
+  - tab3:
+      commands:
+        - echo tab3
+      layout: 
+        - split_horizontally
+  - tab4:
+      foreground: yellow
+      background: blue
+      transparency: 0.1
+      commands:
+        - echo tab4
+
+options:
+  iterm2: true

--- a/lib/termup/cli.rb
+++ b/lib/termup/cli.rb
@@ -17,7 +17,8 @@ module Termup
     map 'l' => :list
     map 's' => :start
 
-    desc 'create PROJECT', 'Create termup project (Shortcut: c)'
+    desc 'create PROJECT', 'Create termup project (Shortcut: c). Use --iterm2 if you would like to use an advanced layout (split panes, etc...)'
+    method_option :iterm2, :type => :boolean, :aliases => "iterm2", :required => false
     def create(project)
       edit(project)
     end
@@ -26,7 +27,11 @@ module Termup
     def edit(project)
       unless File.exists?(path(project))
         empty_directory TERMUP_DIR
-        template 'templates/template.yml', path(project)
+        if options['iterm2']
+          template 'templates/iterm2.yml', path(project)
+        else  
+          template 'templates/template.yml', path(project)
+        end
       end
       say 'please set $EDITOR in ~/.bash_profile' and return unless editor = ENV['EDITOR']
       system("#{editor} #{path(project)}")

--- a/lib/termup/version.rb
+++ b/lib/termup/version.rb
@@ -1,3 +1,3 @@
 module Termup
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end


### PR DESCRIPTION
Kenn, 
i love iTerm2 and your gem. But i wanted to have a more flexible layout mechanism and here is what i've done:

The layout of the yml config file changed a little: 

https://github.com/berk/termup/blob/master/lib/templates/iterm2.yml

You now can set foreground, background and transparency of every tab. You can also execute layout commands after each tab's commands. Here is what you get from the default script:

http://grab.by/i3Xe

For example, if you just want to build a simple 2 by 2. It would be something like this:

https://gist.github.com/4221156

You would create this file by running:

termup create four_squares --iterm2

--iterm2 is a param that indicates that iterm2.yml layout should be used instead of your default template.

Try it out, let me know what you think.

Michael.
